### PR TITLE
Add pkgdown author profiles

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -2,3 +2,11 @@ template:
   params:
     ganalytics: UA-40608305-5
 
+authors:
+  "George Vega Yon":
+    href: "https://ggvy.cl"
+    html: "<img src='https://ggvy.cl/img/george-g-vega-yon-university-of-utah.webp' width=72 alt=''>"
+  "Thomas Valente":
+    href: "https://orcid.org/0000-0002-8824-5816"
+  "Anibal Olivera Morales":
+    href: "https://orcid.org/0009-0000-3736-7939"


### PR DESCRIPTION
## Summary

- link George Vega Yon to https://ggvy.cl and display the portrait from his homepage
- add profile links for every package author listed in DESCRIPTION
- add a source pkgdown configuration where the published site did not already have one

## Validation

- parsed the pkgdown YAML
- verified exact author-name matching against DESCRIPTION
- checked all configured profile and image URLs

Related to gvegayon/website#32.