### PR TITLE
Preserve author names in pkgdown

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -5,7 +5,6 @@ template:
 authors:
   "George Vega Yon":
     href: "https://ggvy.cl"
-    html: "<img src='https://ggvy.cl/img/george-g-vega-yon-university-of-utah.webp' width=72 alt=''>"
   "Thomas Valente":
     href: "https://orcid.org/0000-0002-8824-5816"
   "Anibal Olivera Morales":


### PR DESCRIPTION
## Summary

- remove the html override from George Vega Yon’s pkgdown author metadata
- retain the https://ggvy.cl href so his displayed name remains linked

## Validation

- loaded the package metadata with pkgdown
- verified every configured author mapping contains only an href attribute

Follow-up to #88.